### PR TITLE
Handle: CSS transform -> CSS positioning

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -86,6 +86,13 @@
       return newv;
   }
 
+  function extend(dst, src) {
+    for (var key in src)
+      if (src.hasOwnProperty(key))
+        dst[key] = src[key];
+    return dst;
+  }
+
   var ReactSlider = React.createClass({
     displayName: 'ReactSlider',
 
@@ -230,17 +237,16 @@
     },
 
     _buildHandleStyle: function (offset, i) {
-      var transform = 'translate' + this._axis() + '(' + offset + 'px)';
-      return {
-        WebkitTransform: transform,
-        MozTransform: transform,
-        msTransform: transform,
-        OTransform: transform,
-        transform: transform,
+      var style = {
+        horizontal: { left: offset + 'px' },
+        vertical: { top: offset + 'px' }
+      }[this.props.orientation];
+      extend(style, {
         position: 'absolute',
         willChange: this.state.index >= 0 ? 'transform' : '',
         zIndex: this.state.zIndices.indexOf(i) + 1
-      }
+      });
+      return style;
     },
 
     _buildBarStyle: function (minMax) {


### PR DESCRIPTION
Hey, first off, thanks for your hard work on this awesome component!

Our app uses `transform: rotate(45deg)` to make a diamond-shape handle.

This change allows our style to work. Without it, the transform style applied here overrides what's in the class.

Positioning seems more intuitive, and matches what I've seen in e.g. jQueryUI Slider.

Alternatively:
- To specify multiple transforms to a single element, they need to be concatenated.
- I could nest a second div inside the slider div. It's simpler though to have one element.
