### PR TITLE
Allow disabling the "align" part of trimAlignValue

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -462,14 +462,17 @@
       if (val <= this.props.min) val = this.props.min;
       if (val >= this.props.max) val = this.props.max;
 
-      var valModStep = (val - this.props.min) % this.props.step;
-      var alignValue = val - valModStep;
+      if (this.props.step) {
+        var valModStep = (val - this.props.min) % this.props.step;
+        var alignValue = val - valModStep;
 
-      if (Math.abs(valModStep) * 2 >= this.props.step) {
-        alignValue += (valModStep > 0) ? this.props.step : (-this.props.step);
-      }
+        if (Math.abs(valModStep) * 2 >= this.props.step) {
+          alignValue += (valModStep > 0) ? this.props.step : (-this.props.step);
+        }
 
-      return parseFloat(alignValue.toFixed(5));
+        return parseFloat(alignValue.toFixed(5));
+      } else
+        return val;
     },
 
     _renderHandle: function (styles) {


### PR DESCRIPTION
For some UIs an arbitrary-precision floating point value is perfectly fine. For example, if min and max may be arbitrary precision.

After this change, the developer can set `step` to `null` to disable the "align" behavior. It avoids undesired calls to onChange() during initialization, and when subsequently setting the value.
