### PR TITLE
fix handles not disappearing when changing to fewer values

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -226,6 +226,8 @@
       for (var i = 0; i < value.length; i++) {
         this.state.value[i] = this._trimAlignValue(value[i], newProps);
       }
+      if (this.state.value.length > value.length)
+        this.state.value.length = value.length;
     },
 
     // Check if the arity of `value` or `defaultValue` matches the number of children (= number of custom handles).


### PR DESCRIPTION
When changing from for example 2 values (with 2 handles) to just one value, one handle stays behind.
This fixes the state.value array to have the correct new length.
