### PR TITLE
_handleResize on new props if no upperBound set

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -228,6 +228,12 @@
       }
       if (this.state.value.length > value.length)
         this.state.value.length = value.length;
+
+      // If an upperBound has not yet been determined (due to the component being hidden
+      // during the mount event, or during the last resize), then calculate it now
+      if (this.state.upperBound === 0) {
+        this._handleResize();
+      }
     },
 
     // Check if the arity of `value` or `defaultValue` matches the number of children (= number of custom handles).


### PR DESCRIPTION
This is related to issue #15 

If an upperBound has not been determined (value is 0) during componentWillReceiveProps, then calculate it at that point by calling _handleResize.

This fixes the slider being stuck on zero if it is mounted / resized while hidden, but only if props are (re)set after it is shown.  This is an acceptable solution in my use case, and shouldn't have much of an issue on performance since its only an int comparison once the upperBound is known.
