### PR TITLE
Enforce props.minDistance even on click on slider

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -352,8 +352,13 @@
       var closestIndex = this._getClosestIndex(pixelOffset);
       var nextValue = this._trimAlignValue(this._calcValue(pixelOffset));
 
-      var value = this.state.value;
+      var value = this.state.value.slice(); // Clone this.state.value since we'll modify it temporarily
       value[closestIndex] = nextValue;
+
+      // Prevents the slider from shrinking below `props.minDistance`
+      for (var i = 0; i < value.length - 1; i += 1) {
+        if (value[i + 1] - value[i] < this.props.minDistance) return;
+      }
 
       this.setState({value: value}, callback.bind(this, closestIndex));
     },


### PR DESCRIPTION
Hi,

Thanks for this module! The issue I came across was that you could get a distance shorter than specified in `props.minDistance` by clicking between the bars (I tried with a slider with two bars). Here is my fix.

Cheers!
