### PR TITLE
Wrapping _handleResize() logic in a setTimeout of 0

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -271,21 +271,24 @@
     },
 
     _handleResize: function () {
-      var slider = this.refs.slider.getDOMNode();
-      var handle = this.refs.handle0.getDOMNode();
-      var rect = slider.getBoundingClientRect();
+      // setTimeout of 0 gives element enough time to have assumed its new size if it is being resized
+      window.setTimeout(function() {
+        var slider = this.refs.slider.getDOMNode();
+        var handle = this.refs.handle0.getDOMNode();
+        var rect = slider.getBoundingClientRect();
 
-      var size = this._sizeKey();
+        var size = this._sizeKey();
 
-      var sliderMax = rect[this._posMaxKey()];
-      var sliderMin = rect[this._posMinKey()];
+        var sliderMax = rect[this._posMaxKey()];
+        var sliderMin = rect[this._posMinKey()];
 
-      this.setState({
-        upperBound: slider[size] - handle[size],
-        sliderLength: Math.abs(sliderMax - sliderMin),
-        handleSize: handle[size],
-        sliderStart: this.props.invert ? sliderMax : sliderMin
-      });
+        this.setState({
+          upperBound: slider[size] - handle[size],
+          sliderLength: Math.abs(sliderMax - sliderMin),
+          handleSize: handle[size],
+          sliderStart: this.props.invert ? sliderMax : sliderMin
+        });
+      }.bind(this), 0);
     },
 
     // calculates the offset of a handle in pixels based on its value.


### PR DESCRIPTION
I was facing the issue mentioned in #15, which is that the slider doesn't seem to work if the slider is hidden when the page first loads. Wrapping the logic in `_handleResize()` with a `setTimeout` of 0 gives JS (with it's single-threaded nature) enough time to know what the new size of the element is if the previous height and width were 0.

I'm using these changes live on a [minesweeper app](http://whroman.github.io/minesweeper-react/). The repo lives [here](https://github.com/whroman/minesweeper-react/). The sliders appear if the client clicks on the "new game" button at the bottom of the screen.
