### PR TITLE
Fix an issue with transformed element.

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -276,16 +276,15 @@
       window.setTimeout(function() {
         var slider = this.refs.slider.getDOMNode();
         var handle = this.refs.handle0.getDOMNode();
-        var rect = slider.getBoundingClientRect();
-
+        var direction = this.props.orientation === 'vertical' ? 'Top' : 'Left';
         var size = this._sizeKey();
 
-        var sliderMax = rect[this._posMaxKey()];
-        var sliderMin = rect[this._posMinKey()];
+        var sliderMin = slider['offset' + direction] + slider['client' + direction];
+        var sliderMax = sliderMin + slider[size];
 
         this.setState({
           upperBound: slider[size] - handle[size],
-          sliderLength: Math.abs(sliderMax - sliderMin),
+          sliderLength: slider[size],
           handleSize: handle[size],
           sliderStart: this.props.invert ? sliderMax : sliderMin
         });


### PR DESCRIPTION
This is a workaround for https://github.com/mpowaga/react-slider/issues/44

`getBoundingClientRect` returns dimensions that respect `transform` property. This is kind of correct, but:
- react-slider doesn't know when `transform` property changes (and the usual usage of `transform` is in an animation so it does change),
- `clientWidth` / `clientHeight` is used in other parts of the code, so react-slider doesn't work correctly when it's constantly transformed neither (`clientWidth` / `clientHeight` return element's size before transformation).

Therefore I suggest not using `getBoundingClientRect` function and measure the slider in such way that ignores the transformation. This way the slider works fine after the animation finishes.
