### PR TITLE
Demo link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CSS agnostic slider component for React.
 
-See demo: [https://qwtel.github.io/react-slider](https://qwtel.github.io/react-slider)
+See demo: [http://mpowaga.github.io/react-slider/](http://mpowaga.github.io/react-slider/)
 
 ### Important Note
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CSS agnostic slider component for React.
 
-See demo: [http://mpowaga.github.io/react-slider/](http://mpowaga.github.io/react-slider/)
+See demo: [https://mpowaga.github.io/react-slider/](https://mpowaga.github.io/react-slider/)
 
 ### Important Note
 


### PR DESCRIPTION
The current README points to github page that doesn't work. Point it to this repository's github page.
