### PR TITLE
Fix react 0.14 getDOMNode() deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slider",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Slider component for React",
   "main": "react-slider.js",
   "keywords": [
@@ -23,6 +23,6 @@
     "url": "https://github.com/mpowaga/react-slider.git"
   },
   "peerDependencies": {
-    "react": ">=0.12.1"
+    "react": ">=0.14"
   }
 }

--- a/react-slider.js
+++ b/react-slider.js
@@ -275,8 +275,8 @@
     _handleResize: function () {
       // setTimeout of 0 gives element enough time to have assumed its new size if it is being resized
       this.resizeTimeout = window.setTimeout(function() {
-        var slider = this.refs.slider.getDOMNode();
-        var handle = this.refs.handle0.getDOMNode();
+        var slider = this.refs.slider;
+        var handle = this.refs.handle0;
         var rect = slider.getBoundingClientRect();
 
         var size = this._sizeKey();


### PR DESCRIPTION
Not a really big PR. But it should work with react 0.14
