### PR TITLE
access DOM nodes directly, not using getDOMNode()

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -275,8 +275,8 @@
     _handleResize: function () {
       // setTimeout of 0 gives element enough time to have assumed its new size if it is being resized
       this.resizeTimeout = window.setTimeout(function() {
-        var slider = this.refs.slider.getDOMNode();
-        var handle = this.refs.handle0.getDOMNode();
+        var slider = this.refs.slider;
+        var handle = this.refs.handle0;
         var rect = slider.getBoundingClientRect();
 
         var size = this._sizeKey();


### PR DESCRIPTION
In React v0.14.0, calls to getDOMNode() cause the below warning:

"Warning: ReactDOMComponent: Do not access .getDOMNode() of a DOM node; instead, use the node directly. This DOM node was rendered by `ReactSlider`."

This revision fixes the problem lines.
