### PR TITLE
Fix "This synthetic event is reused for performance reasons" warning

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -15,6 +15,7 @@
   function pauseEvent(e) {
     if (e.stopPropagation) e.stopPropagation();
     if (e.preventDefault) e.preventDefault();
+    e.persist();
     e.cancelBubble = true;
     e.returnValue = false;
     return false;


### PR DESCRIPTION
When dragging the slider, React 15.0 complains:

> Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're adding a new property in the synthetic event object. The property is never released. See https://fb.me/react-event-pooling for more information.

This PR fixes this warning.
