### PR TITLE
A small fix when removing values.

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -688,7 +688,7 @@
         styles[i] = this._buildHandleStyle(offset[i], i);
       }
 
-      var res = this.tempArray;
+      var res = [];
       var renderHandle = this._renderHandle;
       if (React.Children.count(this.props.children) > 0) {
         React.Children.forEach(this.props.children, function (child, i) {


### PR DESCRIPTION
Fixed a bug where react would crash if you want to remove a value. 
In that case, the no. children is greater than the no. values passed, leaving the res array padded with style values instead of react components.
