### PR TITLE
Remove non-standard event features (Fixes "This synthetic event is reused for performance reasons" warning)

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -15,14 +15,11 @@
   function pauseEvent(e) {
     if (e.stopPropagation) e.stopPropagation();
     if (e.preventDefault) e.preventDefault();
-    e.cancelBubble = true;
-    e.returnValue = false;
     return false;
   }
 
   function stopPropagation(e) {
     if (e.stopPropagation) e.stopPropagation();
-    e.cancelBubble = true;
   }
 
   /**


### PR DESCRIPTION
Remove assignment to the Event.cancelBubble and Event.returnValue properties.
These features are non-standard and directly setting these values on an Event
causes a warning in react >= 15.0.0.

This means that we will no longer support Internet Explorer 8, but considering Microsoft ended support for Internet Explorer 8 in January this year I think that's a safe thing to do.

https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelBubble
https://developer.mozilla.org/en-US/docs/Web/API/Event/returnValue
