### PR TITLE
Added max distance and cohesion functionality to react-slider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Must be greater than zero.
 The minimal distance between any pair of handles.
 Zero means they can sit on top of each other.
 
+##### maxDistance {number} default: 0
+
+The maximum distance between any pair of handles.
+Must be positive or zero.
+Zero disables this feature.
+
 ##### defaultValue {oneOfType([number, arrayOf(number)])} default: 0
 
 Determines the initial positions of the handles and the number of handles if the component has no children.
@@ -116,6 +122,11 @@ e.g. `bar-0`, `bar-1`, ...
 ##### pearling {bool} default: false
 
 If `true` the active handle will push other handles within the constraints of `min`, `max`, `step` and `minDistance`.
+
+##### cohesion {bool} default: false
+
+If `true` the active handle will pull other handles within the constraints of `min`, `max`, `step` and `maxDistance`.
+Enabling requires `maxDistance` to be greater than zero.
 
 ##### disabled {bool} default: false
 

--- a/react-slider.js
+++ b/react-slider.js
@@ -388,6 +388,7 @@
     _forceValueFromPosition: function (position, callback) {
       var pixelOffset = this._calcOffsetFromPosition(position);
       var closestIndex = this._getClosestIndex(pixelOffset);
+      var oldValue = this.state.value[closestIndex];
       var nextValue = this._trimAlignValue(this._calcValue(pixelOffset));
 
       var value = this.state.value.slice(); // Clone this.state.value since we'll modify it temporarily
@@ -398,6 +399,16 @@
         if (value[i + 1] - value[i] < this.props.minDistance) return;
       }
 
+      // if "cohesion" is enabled, let the current handle pull the pre- and succeeding handles.
+      if (this.props.maxDistance && this.props.cohesion && value.length > 1) {
+        if (nextValue > oldValue) {
+          this._pullPreceding(value, this.props.maxDistance, closestIndex);
+        }
+        else if (nextValue < oldValue) {
+          this._pullSucceeding(value, this.props.maxDistance, closestIndex);
+        }
+      }
+      
       this.setState({value: value}, callback.bind(this, closestIndex));
     },
 


### PR DESCRIPTION
This adds the "inverse" features to "min distance" and "pearling."

Namely, Setting maxDistance to greater than zero (zero means the feature is disabled) places a hard limit on how far handles can be dragged away from each other.

Cohesion works in tandem with maxDistance to allow handles to stick together after being dragged to the max distance limit. This is important in the scenario where input handle values need to fall within a specific variance of each other.

Note that cohesion plays quite well with pearling, allowing users to create sliders that can be both pushed and pulled with ease. For example, set defaultValue=[0, 20], pearling=true, minDistance=20, cohesion=true, maxDistance=20 and notice how smoothly a hard-defined section of the full range of slider values can be selected. Of course min and max distance can be manipulated easily to make the selection range more dynamic.
