### PR TITLE
Handle props.max == props.min

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -312,7 +312,11 @@
 
     // calculates the offset of a handle in pixels based on its value.
     _calcOffset: function (value) {
-      var ratio = (value - this.props.min) / (this.props.max - this.props.min);
+      var range = this.props.max - this.props.min;
+      if (range === 0) {
+        return 0;
+      }
+      var ratio = (value - this.props.min) / range;
       return ratio * this.state.upperBound;
     },
 


### PR DESCRIPTION
Without this, if max==min then `_calcOffset` returns NaN. This causes the `shallowEqual` call in React's `checkAndWarnForMutatedStyle` to return false because `NaN` equals nothing, including itself.

Fixes #61

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mpowaga/react-slider/85)

<!-- Reviewable:end -->
