### PR TITLE
Use `prop-types` and `create-react-class` packages instead of using from React

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   },
   "peerDependencies": {
     "react": ">=0.14 || ^15.0.0"
+  },
+  "dependencies": {
+    "create-react-class": "^15.5.3",
+    "prop-types": "^15.5.10"
   }
 }

--- a/react-slider.js
+++ b/react-slider.js
@@ -1,3 +1,6 @@
+var PropTypes = require('prop-types');
+var createClass = require('create-react-class');
+
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     define(['react'], factory);
@@ -44,7 +47,7 @@
 
   // undoEnsureArray(ensureArray(x)) === x
 
-  var ReactSlider = React.createClass({
+  var ReactSlider = createClass({
     displayName: 'ReactSlider',
 
     propTypes: {
@@ -52,25 +55,25 @@
       /**
        * The minimum value of the slider.
        */
-      min: React.PropTypes.number,
+      min: PropTypes.number,
 
       /**
        * The maximum value of the slider.
        */
-      max: React.PropTypes.number,
+      max: PropTypes.number,
 
       /**
        * Value to be added or subtracted on each step the slider makes.
        * Must be greater than zero.
        * `max - min` should be evenly divisible by the step value.
        */
-      step: React.PropTypes.number,
+      step: PropTypes.number,
 
       /**
        * The minimal distance between any pair of handles.
        * Must be positive, but zero means they can sit on top of each other.
        */
-      minDistance: React.PropTypes.number,
+      minDistance: PropTypes.number,
 
       /**
        * Determines the initial positions of the handles and the number of handles if the component has no children.
@@ -80,28 +83,28 @@
        * The values in the array must be sorted.
        * If the component has children, the length of the array must match the number of children.
        */
-      defaultValue: React.PropTypes.oneOfType([
-        React.PropTypes.number,
-        React.PropTypes.arrayOf(React.PropTypes.number)
+      defaultValue: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.number)
       ]),
 
       /**
        * Like `defaultValue` but for [controlled components](http://facebook.github.io/react/docs/forms.html#controlled-components).
        */
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.number,
-        React.PropTypes.arrayOf(React.PropTypes.number)
+      value: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.arrayOf(PropTypes.number)
       ]),
 
       /**
        * Determines whether the slider moves horizontally (from left to right) or vertically (from top to bottom).
        */
-      orientation: React.PropTypes.oneOf(['horizontal', 'vertical']),
+      orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 
       /**
        * The css class set on the slider node.
        */
-      className: React.PropTypes.string,
+      className: PropTypes.string,
 
       /**
        * The css class set on each handle node.
@@ -109,66 +112,66 @@
        * In addition each handle will receive a numbered css class of the form `${handleClassName}-${i}`,
        * e.g. `handle-0`, `handle-1`, ...
        */
-      handleClassName: React.PropTypes.string,
+      handleClassName: PropTypes.string,
 
       /**
        * The css class set on the handle that is currently being moved.
        */
-      handleActiveClassName: React.PropTypes.string,
+      handleActiveClassName: PropTypes.string,
 
       /**
        * If `true` bars between the handles will be rendered.
        */
-      withBars: React.PropTypes.bool,
+      withBars: PropTypes.bool,
 
       /**
        * The css class set on the bars between the handles.
        * In addition bar fragment will receive a numbered css class of the form `${barClassName}-${i}`,
        * e.g. `bar-0`, `bar-1`, ...
        */
-      barClassName: React.PropTypes.string,
+      barClassName: PropTypes.string,
 
       /**
        * If `true` the active handle will push other handles
        * within the constraints of `min`, `max`, `step` and `minDistance`.
        */
-      pearling: React.PropTypes.bool,
+      pearling: PropTypes.bool,
 
       /**
        * If `true` the handles can't be moved.
        */
-      disabled: React.PropTypes.bool,
+      disabled: PropTypes.bool,
 
       /**
        * Disables handle move when clicking the slider bar
        */
-      snapDragDisabled: React.PropTypes.bool,
+      snapDragDisabled: PropTypes.bool,
 
       /**
        * Inverts the slider.
        */
-      invert: React.PropTypes.bool,
+      invert: PropTypes.bool,
 
       /**
        * Callback called before starting to move a handle.
        */
-      onBeforeChange: React.PropTypes.func,
+      onBeforeChange: PropTypes.func,
 
       /**
        * Callback called on every value change.
        */
-      onChange: React.PropTypes.func,
+      onChange: PropTypes.func,
 
       /**
        * Callback called only after moving a handle has ended.
        */
-      onAfterChange: React.PropTypes.func,
+      onAfterChange: PropTypes.func,
 
       /**
        *  Callback called when the the slider is clicked (handle or bars).
        *  Receives the value at the clicked position as argument.
        */
-      onSliderClick: React.PropTypes.func
+      onSliderClick: PropTypes.func
     },
 
     getDefaultProps: function () {


### PR DESCRIPTION
React.PropTypes and React.createClass are deprecated as of React 15.5

Addresses #102 