### PR TITLE
Removed use of `tempArray`

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -194,9 +194,6 @@
     getInitialState: function () {
       var value = this._or(ensureArray(this.props.value), ensureArray(this.props.defaultValue));
 
-      // reused throughout the component to store results of iterations over `value`
-      this.tempArray = value.slice();
-
       // array for storing resize timeouts ids
       this.pendingResizeTimeouts = [];
 
@@ -219,9 +216,6 @@
     // This basically allows the slider to be a controlled component.
     componentWillReceiveProps: function (newProps) {
       var value = this._or(ensureArray(newProps.value), this.state.value);
-
-      // ensure the array keeps the same size as `value`
-      this.tempArray = value.slice();
 
       for (var i = 0; i < value.length; i++) {
         this.state.value[i] = this._trimAlignValue(value[i], newProps);
@@ -753,12 +747,12 @@
     _renderHandles: function (offset) {
       var length = offset.length;
 
-      var styles = this.tempArray;
+      var styles = new Array(length);
       for (var i = 0; i < length; i++) {
         styles[i] = this._buildHandleStyle(offset[i], i);
       }
 
-      var res = this.tempArray;
+      var res = new Array(length);
       var renderHandle = this._renderHandle;
       if (React.Children.count(this.props.children) > 0) {
         React.Children.forEach(this.props.children, function (child, i) {
@@ -833,9 +827,9 @@
       var state = this.state;
       var props = this.props;
 
-      var offset = this.tempArray;
       var value = state.value;
       var l = value.length;
+      var offset = new Array(l);
       for (var i = 0; i < l; i++) {
         offset[i] = this._calcOffset(value[i], i);
       }


### PR DESCRIPTION
After updating my project to react@16.0.0 I experienced strange issue where position of handles would be wrong on initial load. After debugging I determined the issue is caused by re-use of `tempArray` to generate some arrays. As far as I know react uses simple object equality `===` when detecting changes of props and state. Because the array was re-used in some cases react would fail to detect changes in style object.

Fixes #115 