### PR TITLE
prevent default page scroll when using ArrowUp/ArrowDown

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -545,9 +545,11 @@
       switch (e.key) {
         case "ArrowLeft":
         case "ArrowUp":
+          e.preventDefault();
           return this._moveDownOneStep();
         case "ArrowRight":
         case "ArrowDown":
+          e.preventDefault();
           return this._moveUpOneStep();
         case "Home":
           return this._move(this.props.min);


### PR DESCRIPTION
When the page height is greater than the viewport height ArrowUp and ArrowDown are used to move the page up and down for a key board user.

Currently when the focus is on the slider handle ArrowUp and ArrowDown can have the unintended side effect of also scrolling the page as well as moving the handle.

By adding e.preventDefault only the handle will move, and the page will not scroll. Once the user tabs away from the slider the page can again be scrolled using the arrow keys.