### PR TITLE
fix: do not mutate tempArray when creating handles

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -758,7 +758,7 @@
         styles[i] = this._buildHandleStyle(offset[i], i);
       }
 
-      var res = this.tempArray;
+      var res = [];
       var renderHandle = this._renderHandle;
       if (React.Children.count(this.props.children) > 0) {
         React.Children.forEach(this.props.children, function (child, i) {


### PR DESCRIPTION
created from the fork by @misino, fix#115

> Even if component is defined with defaultValue bigger than 0, the handle can be rendered at position `left: 0px`.
> The render method of react-slider component is called twice at the beginning because of handleResize event which calls setState. On first render, it calculates left as 0, second render sets correct left value.
> The issue occurs in React version 16, which implements optimized diffing of DOM changes.
> Handle components are not rerendered second time, because they are returned as mutated tempArray. It means that the object reference of handle components is not changed between first and second render. And react 16 evaluates it as no change DOM change.

I've tested these changes and they do fix the handle issues in React 16