### PR TITLE
Fix aria keyboard support for directional arrows

### DIFF
--- a/react-slider.js
+++ b/react-slider.js
@@ -553,11 +553,11 @@
       if (e.ctrlKey || e.shiftKey || e.altKey) return;
       switch (e.key) {
         case "ArrowLeft":
-        case "ArrowUp":
+        case "ArrowDown":
           e.preventDefault();
           return this._moveDownOneStep();
         case "ArrowRight":
-        case "ArrowDown":
+        case "ArrowUp":
           e.preventDefault();
           return this._moveUpOneStep();
         case "Home":


### PR DESCRIPTION
Per aria examples, left and down should decrease, up and right should increase:
https://www.w3.org/TR/wai-aria-practices/examples/slider/slider-1.html


Key | Function
-- | --
Right Arrow | Increases slider value one step.
Up Arrow | Increases slider value one step.
Left Arrow | Decreases slider value one step.
Down Arrow | Decreases slider value one step.

