### PR TITLE
Fix onAfterChange

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,9 @@ const { createJestConfig } = require('create-react-styleguide');
 
 module.exports = createJestConfig({
     /* your own config shallowly merged */
-    setupFilesAfterEnv: ['jest-styled-components'],
+    testEnvironment: 'jsdom',
+    setupFilesAfterEnv: [
+        '@testing-library/react/cleanup-after-each',
+        'jest-styled-components',
+    ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1148,6 +1148,86 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
+    "@testing-library/dom": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
+      "integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.2.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@jest/types": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+          "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^12.0.9"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+          "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.8.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.7.tgz",
+      "integrity": "sha512-6XoeWSr3UCdxMswbkW0BmuXYw8a6w+stt+5gg4D4zAcljfhXETQ5o28bjJFwNab4OPg8gBNK8KIVot86L4Q8Vg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.4",
+        "@testing-library/dom": "^5.5.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.1.tgz",
@@ -1194,6 +1274,25 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
       "integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
       "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "@types/node": {
       "version": "11.13.5",
@@ -12737,6 +12836,12 @@
       "requires": {
         "browser-process-hrtime": "^0.1.2"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.2.0.tgz",
+      "integrity": "sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prop-types": "^15.6"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.7",
     "babel-plugin-styled-components": "^1.10.0",
     "babel-preset-zillow": "^4.0.3",
     "create-react-styleguide": "^4.0.3",

--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -354,12 +354,16 @@ class ReactSlider extends React.Component {
     };
 
     onBlur = () => {
-        this.setState({ index: -1 }, this.onEnd(this.getKeyDownEventMap()));
+        console.log('onBlur');
+        this.setState({ index: -1 }, () => {
+            this.onEnd(this.getKeyDownEventMap());
+        });
     };
 
     onEnd(eventMap) {
+        console.log('onEnd');
         removeHandlers(eventMap);
-        this.fireChangeEvent.bind(this, 'onAfterChange');
+        this.fireChangeEvent.call(this, 'onAfterChange');
     }
 
     onMouseMove = e => {
@@ -584,6 +588,10 @@ class ReactSlider extends React.Component {
 
     resize() {
         const { slider } = this;
+        if (!slider) {
+            return;
+        }
+
         const thumb = this.thumb0;
         const rect = slider.getBoundingClientRect();
 
@@ -832,7 +840,9 @@ class ReactSlider extends React.Component {
     }
 
     fireChangeEvent(event) {
+        console.log('fireChangeEvent');
         if (this.props[event]) {
+            console.log(`Firing ${event}()`);
             this.props[event](undoEnsureArray(this.state.value));
         }
     }

--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -354,14 +354,12 @@ class ReactSlider extends React.Component {
     };
 
     onBlur = () => {
-        console.log('onBlur');
         this.setState({ index: -1 }, () => {
             this.onEnd(this.getKeyDownEventMap());
         });
     };
 
     onEnd(eventMap) {
-        console.log('onEnd');
         removeHandlers(eventMap);
         this.fireChangeEvent.call(this, 'onAfterChange');
     }
@@ -840,9 +838,7 @@ class ReactSlider extends React.Component {
     }
 
     fireChangeEvent(event) {
-        console.log('fireChangeEvent');
         if (this.props[event]) {
-            console.log(`Firing ${event}()`);
             this.props[event](undoEnsureArray(this.state.value));
         }
     }

--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -6,6 +6,7 @@ Single slider, similar to `<input type="range" defaultValue={0} />`
     thumbClassName="example-thumb"
     trackClassName="example-track"
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+    onAfterChange={() => { console.log('onAfterChange') }}
 />
 ```
 

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { render, fireEvent } from '@testing-library/react';
 import ReactSlider from '../../../index';
 
 describe('<ReactSlider>', () => {
@@ -8,11 +9,19 @@ describe('<ReactSlider>', () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it('should call onAfterChange callback when onEnd is called', () => {
+    it('should call onAfterChange callback', () => {
         const onAfterChange = jest.fn();
-        const testRenderer = renderer.create(<ReactSlider onAfterChange={onAfterChange} />);
-        const testInstance = testRenderer.root;
-        testInstance.instance.onBlur();
+        const { container } = render(
+            <ReactSlider onAfterChange={onAfterChange} thumbClassName="thumb" />
+        );
+        const thumb = container.querySelector('.thumb');
+        /**
+         * Without mocking focus(), jsdom throws `TypeError: stack.split is not a function`.
+         */
+        thumb.focus = () => {};
+        fireEvent.touchStart(thumb, { touches: [{ pageX: 0, pageY: 0 }] });
+        fireEvent.touchMove(thumb, { touches: [{ pageX: 1, pageY: 0 }] });
+        fireEvent.touchEnd(thumb, { touches: [{ pageX: 2, pageY: 0 }] });
         expect(onAfterChange).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -7,4 +7,12 @@ describe('<ReactSlider>', () => {
         const tree = renderer.create(<ReactSlider />).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    it('should call onAfterChange callback when onEnd is called', () => {
+        const onAfterChange = jest.fn();
+        const testRenderer = renderer.create(<ReactSlider onAfterChange={onAfterChange} />);
+        const testInstance = testRenderer.root;
+        testInstance.instance.onBlur();
+        expect(onAfterChange).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
Hey!

At the moment `onAfterChange` is never called, this PR fix that.

`98ce07d` - uses `react-test-renderer` and basically checks if `onBlur` calls `onAfterChange`

---

`98e1842` - adds `react-testing-library` and uses touch events to check if `onAfterChange` has been called which seems a bit better way to test it.

I had to mock `.focus()` which is called in `start()` method because of `jsdom` issue.
You can choose a specific commit, so I will rebase and squash commits.