### PR TITLE
fix: change event handlers are now more reliable

### DIFF
--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -57,6 +57,20 @@ Vertical slider
 />
 ```
 
+Track changes with `onBeforeChange`, `onChange`, and `onAfterChange` event handlers
+
+```jsx
+<ReactSlider
+    className="horizontal-slider"
+    thumbClassName="example-thumb"
+    trackClassName="example-track"
+    onBeforeChange={val => console.log('onBeforeChange value:', val)}
+    onChange={val => console.log('onChange value:', val)}
+    onAfterChange={val => console.log('onAfterChange value:', val)}
+    renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+/>
+```
+
 Custom styling using [styled-components](https://www.styled-components.com/)
 
 ```jsx

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -8,13 +8,220 @@ describe('<ReactSlider>', () => {
         expect(tree).toMatchSnapshot();
     });
 
-    it('should call onAfterChange callback when onEnd is called', () => {
-        const onAfterChange = jest.fn();
-        const testRenderer = renderer.create(<ReactSlider onAfterChange={onAfterChange} />);
-        const testInstance = testRenderer.root;
+    describe('event handlers', () => {
+        beforeEach(() => {
+            global.document = {
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+            };
+        });
 
-        expect(onAfterChange).not.toHaveBeenCalled();
-        testInstance.instance.onBlur();
-        expect(onAfterChange).toHaveBeenCalledTimes(1);
+        afterEach(() => {
+            delete global.document;
+        });
+
+        it('does not call any event handlers if the value does not change', () => {
+            const onBeforeChange = jest.fn();
+            const onChange = jest.fn();
+            const onAfterChange = jest.fn();
+            const testRenderer = renderer.create(
+                <ReactSlider
+                    onBeforeChange={onBeforeChange}
+                    onChange={onChange}
+                    onAfterChange={onAfterChange}
+                    thumbClassName="test-thumb"
+                    min={0}
+                    step={1}
+                />
+            );
+
+            const testInstance = testRenderer.root;
+            const thumb = testInstance.findByProps({ className: 'test-thumb test-thumb-0 ' });
+
+            const { addEventListener } = global.document;
+            expect(addEventListener).not.toHaveBeenCalled();
+
+            // simulate focus on thumb
+            thumb.props.onFocus();
+
+            expect(addEventListener).toHaveBeenCalledTimes(3);
+            expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+            expect(addEventListener.mock.calls[1][0]).toBe('keyup');
+            expect(addEventListener.mock.calls[2][0]).toBe('focusout');
+
+            const onKeyDown = addEventListener.mock.calls[0][1];
+
+            expect(onBeforeChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
+            expect(onAfterChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
+
+            expect(onBeforeChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
+            expect(onAfterChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'Home', preventDefault: () => {} });
+
+            expect(onBeforeChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
+            expect(onAfterChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'PageDown', preventDefault: () => {} });
+
+            expect(onBeforeChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
+            expect(onAfterChange).not.toHaveBeenCalled();
+        });
+
+        it('calls onBeforeChange only once before onChange', () => {
+            const onBeforeChange = jest.fn();
+            const onChange = jest.fn();
+            const testRenderer = renderer.create(
+                <ReactSlider
+                    onBeforeChange={onBeforeChange}
+                    onChange={onChange}
+                    thumbClassName="test-thumb"
+                    min={0}
+                    step={1}
+                />
+            );
+
+            const testInstance = testRenderer.root;
+            const thumb = testInstance.findByProps({ className: 'test-thumb test-thumb-0 ' });
+
+            const { addEventListener } = global.document;
+            expect(addEventListener).not.toHaveBeenCalled();
+
+            // simulate focus on thumb
+            thumb.props.onFocus();
+
+            expect(addEventListener).toHaveBeenCalledTimes(3);
+            expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+            expect(addEventListener.mock.calls[1][0]).toBe('keyup');
+            expect(addEventListener.mock.calls[2][0]).toBe('focusout');
+
+            const onKeyDown = addEventListener.mock.calls[0][1];
+
+            expect(onBeforeChange).not.toHaveBeenCalled();
+            expect(onChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            expect(onBeforeChange).toHaveBeenCalledTimes(1);
+            expect(onBeforeChange).toHaveBeenCalledWith(0);
+            expect(onBeforeChange.mock.invocationCallOrder[0]).toBeLessThan(
+                onChange.mock.invocationCallOrder[0]
+            );
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenCalledWith(1);
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            expect(onBeforeChange).toHaveBeenCalledTimes(1);
+            expect(onBeforeChange).toHaveBeenCalledWith(0);
+            expect(onChange).toHaveBeenCalledTimes(2);
+            expect(onChange).toHaveBeenCalledWith(2);
+        });
+
+        it('calls onChange for every change', () => {
+            const onChange = jest.fn();
+            const testRenderer = renderer.create(
+                <ReactSlider onChange={onChange} thumbClassName="test-thumb" min={0} step={1} />
+            );
+
+            const testInstance = testRenderer.root;
+            const thumb = testInstance.findByProps({ className: 'test-thumb test-thumb-0 ' });
+
+            const { addEventListener } = global.document;
+            expect(addEventListener).not.toHaveBeenCalled();
+
+            // simulate focus on thumb
+            thumb.props.onFocus();
+
+            expect(addEventListener).toHaveBeenCalledTimes(3);
+            expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+            expect(addEventListener.mock.calls[1][0]).toBe('keyup');
+            expect(addEventListener.mock.calls[2][0]).toBe('focusout');
+
+            const onKeyDown = addEventListener.mock.calls[0][1];
+
+            expect(onChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenCalledWith(1);
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
+
+            expect(onChange).toHaveBeenCalledTimes(2);
+            expect(onChange).toHaveBeenCalledWith(0);
+        });
+
+        it('calls onAfterChange only once after onChange', () => {
+            const onChange = jest.fn();
+            const onAfterChange = jest.fn();
+            const testRenderer = renderer.create(
+                <ReactSlider
+                    onChange={onChange}
+                    onAfterChange={onAfterChange}
+                    thumbClassName="test-thumb"
+                    min={0}
+                    step={1}
+                />
+            );
+
+            const testInstance = testRenderer.root;
+            const thumb = testInstance.findByProps({ className: 'test-thumb test-thumb-0 ' });
+
+            const { addEventListener } = global.document;
+            expect(addEventListener).not.toHaveBeenCalled();
+
+            // simulate focus on thumb
+            thumb.props.onFocus();
+
+            expect(addEventListener).toHaveBeenCalledTimes(3);
+            expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+            expect(addEventListener.mock.calls[1][0]).toBe('keyup');
+            expect(addEventListener.mock.calls[2][0]).toBe('focusout');
+
+            const onKeyDown = addEventListener.mock.calls[0][1];
+            const onKeyUp = addEventListener.mock.calls[1][1];
+
+            expect(onChange).not.toHaveBeenCalled();
+            expect(onAfterChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenCalledWith(1);
+            expect(onAfterChange).not.toHaveBeenCalled();
+
+            // simulate keydown
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            expect(onChange).toHaveBeenCalledTimes(2);
+            expect(onChange).toHaveBeenCalledWith(2);
+            expect(onAfterChange).not.toHaveBeenCalled();
+
+            // simulate keyup
+            onKeyUp();
+
+            expect(onChange).toHaveBeenCalledTimes(2);
+            expect(onAfterChange).toHaveBeenCalledTimes(1);
+            expect(onAfterChange).toHaveBeenCalledWith(2);
+            expect(onAfterChange.mock.invocationCallOrder[0]).toBeGreaterThan(
+                onChange.mock.invocationCallOrder[1]
+            );
+        });
     });
 });


### PR DESCRIPTION
`onBeforeChange` and `onAfterChange` should only be called once per action,
and none of the change events should fire if the action does not result in a change in value.

Fixes #161