### PR TITLE
fix: prevent vertical scroll on thumb touch (#171)

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -879,6 +879,7 @@ class ReactSlider extends React.Component {
     buildThumbStyle(offset, i) {
         const style = {
             position: 'absolute',
+            touchAction: 'none',
             willChange: this.state.index >= 0 ? this.posMinKey() : '',
             zIndex: this.state.zIndices.indexOf(i) + 1,
         };


### PR DESCRIPTION
May need a workaround or polyfill for browsers that do not support touch-action
Closes #171

Detailed explanation: https://github.com/zillow/react-slider/issues/171#issuecomment-626350678