### PR TITLE
Fixing "Both slider handles on the min side..."

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -343,7 +343,7 @@ class ReactSlider extends React.Component {
         // If an upperBound has not yet been determined (due to the component being hidden
         // during the mount event, or during the last resize), then calculate it now
         if (this.state.upperBound === 0) {
-            this.resize();
+            this.handleResize();
         }
     }
 


### PR DESCRIPTION
Fixing Both slider handles on the min side when rendering slider in a dropdown https://github.com/zillow/react-slider/issues/136

This fix might also be applied to line 320, where this.resize() is beeing used, but specifically on this problem it happens during the UNSAFE_componentWillReceiveProps lifecycle

Following is a quick and dirty example to reproduce and test this behavior

Usage in a dropdown functionality

```jsx
import React, { useState } from "react";
import ReactSlider from "./ReactSlider";

const TestDropdown = props => {
  const [open, setOpen] = useState(false);

  return (
    <>
      <div
        style={{ width: "100%", height: "24px", backgroundColor: "blue" }}
        onClick={() => setOpen(!open)}
      />
      <div style={{ display: open ? "block" : "none", width: "100%" }}>
        {
          <ReactSlider
            defaultValue={[15, 60]}
            max={60}
            min={5}
            renderThumb={(props, state) => (
              <div
                {...props}
                style={{
                  ...props.style,
                  backgroundColor: "#000",
                  color: "#fff",
                  padding: 10
                }}
              >
                {state.valueNow}
              </div>
            )}
            renderTrack={(props, state) => (
              <div
                {...props}
                style={{
                  ...props.style,
                  border: "20px solid #f00"
                }}
              ></div>
            )}
          />
        }
      </div>
    </>
  );
};

<TestDropdown />;
```
