### PR TITLE
feat: Adding a new ariaLabelledby prop for use with Assistive Technologies

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -262,6 +262,13 @@ class ReactSlider extends React.Component {
         ariaLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
 
         /**
+         * aria-labelledby for screen-readers to apply to the thumbs.
+         * Used when slider rendered with separate label.
+         */
+        // eslint-disable-next-line zillow/react/require-default-props
+        ariaLabelledby: PropTypes.string,
+
+        /**
          * aria-valuetext for screen-readers.
          * Can be a static string, or a function that returns a string.
          * The function will be passed a single argument,
@@ -995,6 +1002,7 @@ class ReactSlider extends React.Component {
             'aria-label': Array.isArray(this.props.ariaLabel)
                 ? this.props.ariaLabel[i]
                 : this.props.ariaLabel,
+            'aria-labelledby': this.props.ariaLabelledby,
         };
 
         const state = {

--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -264,9 +264,14 @@ class ReactSlider extends React.Component {
         /**
          * aria-labelledby for screen-readers to apply to the thumbs.
          * Used when slider rendered with separate label.
+         * Use an array for more than one thumb.
+         * The length of the array must match the number of thumbs in the value array.
          */
         // eslint-disable-next-line zillow/react/require-default-props
-        ariaLabelledby: PropTypes.string,
+        ariaLabelledby: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.arrayOf(PropTypes.string),
+        ]),
 
         /**
          * aria-valuetext for screen-readers.
@@ -1002,7 +1007,9 @@ class ReactSlider extends React.Component {
             'aria-label': Array.isArray(this.props.ariaLabel)
                 ? this.props.ariaLabel[i]
                 : this.props.ariaLabel,
-            'aria-labelledby': this.props.ariaLabelledby,
+            'aria-labelledby': Array.isArray(this.props.ariaLabelledby)
+                ? this.props.ariaLabelledby[i]
+                : this.props.ariaLabelledby,
         };
 
         const state = {

--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -49,7 +49,6 @@ Double slider
     trackClassName="example-track"
     defaultValue={[0, 100]}
     ariaLabel={['Lower thumb', 'Upper thumb']}
-    ariaLabelledby={['Left thumb label', 'Right thumb label']}
     ariaValuetext={state => `Thumb value ${state.valueNow}`}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     pearling
@@ -66,7 +65,6 @@ Multi slider
     trackClassName="example-track"
     defaultValue={[0, 50, 100]}
     ariaLabel={['Leftmost thumb', 'Middle thumb', 'Rightmost thumb']}
-    ariaLabelledby={['Left thumb label', 'Middle thumb label', 'Right thumb label']}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     pearling
     minDistance={10}
@@ -82,7 +80,6 @@ Vertical slider
     trackClassName="example-track"
     defaultValue={[0, 50, 100]}
     ariaLabel={['Lowest thumb', 'Middle thumb', 'Top thumb']}
-    ariaLabelledby={['Left thumb label', 'Middle thumb label', 'Right thumb label']}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     orientation="vertical"
     invert
@@ -102,7 +99,6 @@ Vertical slider with marks at an interval
     defaultValue={[0, 50, 100]}
     marks={25}
     ariaLabel={['Lowest thumb', 'Middle thumb', 'Top thumb']}
-    ariaLabelledby={['Left thumb label', 'Middle thumb label', 'Right thumb label']}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     orientation="vertical"
     invert
@@ -254,3 +250,44 @@ const ResizableSlider = () => {
 
 <ResizableSlider />
 ```
+
+Single slider, applying `ariaLabelledby` to establish association with a label
+
+```jsx
+<div>
+    <label id="slider-label" htmlFor="slider">
+        React Slider example
+    </label>
+    <ReactSlider
+        ariaLabelledby="slider-label"
+        className="horizontal-slider"
+        thumbClassName="example-thumb"
+        trackClassName="example-track"
+        renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+    />
+</div>
+```
+
+Double slider, applying `ariaLabelledby` as an array to multiple thumb labels
+
+```jsx
+<div>
+    <label id="first-slider-label" htmlFor="slider">
+        Start slider label
+    </label>
+    <label id="second-slider-label" htmlFor="slider">
+        End slider label
+    </label>
+    <ReactSlider
+        className="horizontal-slider"
+        thumbClassName="example-thumb"
+        trackClassName="example-track"
+        defaultValue={[0, 100]}
+        ariaLabel={['Lower thumb', 'Upper thumb']}
+        ariaLabelledby={['first-slider-label', 'second-slider-label']}
+        ariaValuetext={state => `Thumb value ${state.valueNow}`}
+        renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+        pearling
+        minDistance={10}
+    />
+</div>

--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -49,7 +49,7 @@ Double slider
     trackClassName="example-track"
     defaultValue={[0, 100]}
     ariaLabel={['Lower thumb', 'Upper thumb']}
-    ariaLabelledby="Slider label"
+    ariaLabelledby={['Left thumb label', 'Right thumb label']}
     ariaValuetext={state => `Thumb value ${state.valueNow}`}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     pearling
@@ -66,7 +66,7 @@ Multi slider
     trackClassName="example-track"
     defaultValue={[0, 50, 100]}
     ariaLabel={['Leftmost thumb', 'Middle thumb', 'Rightmost thumb']}
-    ariaLabelledby="Slider label"
+    ariaLabelledby={['Left thumb label', 'Middle thumb label', 'Right thumb label']}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     pearling
     minDistance={10}
@@ -82,7 +82,7 @@ Vertical slider
     trackClassName="example-track"
     defaultValue={[0, 50, 100]}
     ariaLabel={['Lowest thumb', 'Middle thumb', 'Top thumb']}
-    ariaLabelledby="Slider label"
+    ariaLabelledby={['Left thumb label', 'Middle thumb label', 'Right thumb label']}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     orientation="vertical"
     invert
@@ -102,7 +102,7 @@ Vertical slider with marks at an interval
     defaultValue={[0, 50, 100]}
     marks={25}
     ariaLabel={['Lowest thumb', 'Middle thumb', 'Top thumb']}
-    ariaLabelledby="Slider label"
+    ariaLabelledby={['Left thumb label', 'Middle thumb label', 'Right thumb label']}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     orientation="vertical"
     invert

--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -49,6 +49,7 @@ Double slider
     trackClassName="example-track"
     defaultValue={[0, 100]}
     ariaLabel={['Lower thumb', 'Upper thumb']}
+    ariaLabelledby="Slider label"
     ariaValuetext={state => `Thumb value ${state.valueNow}`}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     pearling
@@ -65,6 +66,7 @@ Multi slider
     trackClassName="example-track"
     defaultValue={[0, 50, 100]}
     ariaLabel={['Leftmost thumb', 'Middle thumb', 'Rightmost thumb']}
+    ariaLabelledby="Slider label"
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     pearling
     minDistance={10}
@@ -80,6 +82,7 @@ Vertical slider
     trackClassName="example-track"
     defaultValue={[0, 50, 100]}
     ariaLabel={['Lowest thumb', 'Middle thumb', 'Top thumb']}
+    ariaLabelledby="Slider label"
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     orientation="vertical"
     invert
@@ -99,6 +102,7 @@ Vertical slider with marks at an interval
     defaultValue={[0, 50, 100]}
     marks={25}
     ariaLabel={['Lowest thumb', 'Middle thumb', 'Top thumb']}
+    ariaLabelledby="Slider label"
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
     orientation="vertical"
     invert

--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -255,7 +255,7 @@ Single slider, applying `ariaLabelledby` to establish association with a label
 
 ```jsx
 <div>
-    <label id="slider-label" htmlFor="slider">
+    <label id="slider-label">
         React Slider example
     </label>
     <ReactSlider
@@ -272,10 +272,10 @@ Double slider, applying `ariaLabelledby` as an array to multiple thumb labels
 
 ```jsx
 <div>
-    <label id="first-slider-label" htmlFor="slider">
+    <label id="first-slider-label">
         Start slider label
     </label>
-    <label id="second-slider-label" htmlFor="slider">
+    <label id="second-slider-label">
         End slider label
     </label>
     <ReactSlider
@@ -283,7 +283,6 @@ Double slider, applying `ariaLabelledby` as an array to multiple thumb labels
         thumbClassName="example-thumb"
         trackClassName="example-track"
         defaultValue={[0, 100]}
-        ariaLabel={['Lower thumb', 'Upper thumb']}
         ariaLabelledby={['first-slider-label', 'second-slider-label']}
         ariaValuetext={state => `Thumb value ${state.valueNow}`}
         renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}


### PR DESCRIPTION
Hello 👋 

Raising a PR to add an `aria-labelledby` property to the slider.

When using the slider with a separate `<label>` component to describe the component, when running `axe` tests we found that there was no way to tie the slider back to the label other than `aria-label`.

Hope this PR makes sense and follows contributions correctly. Thanks also for a great library!