### PR TITLE
fix: ignore meta key events in keyDown handler

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -489,7 +489,7 @@ class ReactSlider extends React.Component {
     };
 
     onKeyDown = e => {
-        if (e.ctrlKey || e.shiftKey || e.altKey) {
+        if (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) {
             return;
         }
 


### PR DESCRIPTION
On macOS the meta key is often used for commands. Thus if doing an action such as undo the slider will not update until the `cmd` key is released.