### PR TITLE
feat: add pushed thumbs indices to on change events

### DIFF
--- a/src/components/ReactSlider/ReactSlider.md
+++ b/src/components/ReactSlider/ReactSlider.md
@@ -115,8 +115,8 @@ Track changes with `onBeforeChange`, `onChange`, and `onAfterChange` event handl
     thumbClassName="example-thumb"
     trackClassName="example-track"
     onBeforeChange={(value, index) => console.log(`onBeforeChange: ${JSON.stringify({ value, index })}`)}
-    onChange={(value, index) => console.log(`onChange: ${JSON.stringify({ value, index })}`)}
-    onAfterChange={(value, index) => console.log(`onAfterChange: ${JSON.stringify({ value, index })}`)}
+    onChange={(value, index, pushed) => console.log(`onChange: ${JSON.stringify({ value, index, pushed })}`)}
+    onAfterChange={(value, index, pushed) => console.log(`onAfterChange: ${JSON.stringify({ value, index, pushed })}`)}
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
 />
 ```
@@ -129,12 +129,32 @@ const [value, setValue] = React.useState([25, 50]);
 <ReactSlider
     value={value}
     onBeforeChange={(value, index) => console.log(`onBeforeChange: ${JSON.stringify({ value, index })}`)}
-    onChange={(value, index) => console.log(`onChange: ${JSON.stringify({ value, index })}`)}
-    onAfterChange={(value, index) => console.log(`onAfterChange: ${JSON.stringify({ value, index })}`)}
+    onChange={(value, index, pushed) => {
+        setValue(value);
+        console.log(`onChange: ${JSON.stringify({ value, index, pushed })}`);
+    }}
+    onAfterChange={(value, index, pushed) => console.log(`onAfterChange: ${JSON.stringify({ value, index, pushed })}`)}
     className="horizontal-slider"
     thumbClassName="example-thumb"
     trackClassName="example-track"
     renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+    pearling
+/>
+```
+
+`onChange` and `onAfterChange` can tell you which thumbs are being or have been pushed by the current thumb due to pearling.
+
+```jsx
+<ReactSlider
+    className="horizontal-slider"
+    thumbClassName="example-thumb"
+    trackClassName="example-track"
+    defaultValue={[25, 50, 75]}
+    onChange={(value, index, pushed) => console.log(`onChange: ${JSON.stringify({ value, index, pushed })}`)}
+    onAfterChange={(value, index, pushed) => console.log(`onAfterChange: ${JSON.stringify({ value, index, pushed })}`)}
+    renderThumb={(props, state) => <div {...props}>{state.valueNow}</div>}
+    pearling
+    minDistance={10}
 />
 ```
 

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -119,7 +119,7 @@ describe('<ReactSlider>', () => {
                 onChange.mock.invocationCallOrder[0]
             );
             expect(onChange).toHaveBeenCalledTimes(1);
-            expect(onChange).toHaveBeenCalledWith(1, 0);
+            expect(onChange).toHaveBeenCalledWith(1, 0, []);
 
             // simulate keydown
             onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
@@ -127,7 +127,7 @@ describe('<ReactSlider>', () => {
             expect(onBeforeChange).toHaveBeenCalledTimes(1);
             expect(onBeforeChange).toHaveBeenCalledWith(0, 0);
             expect(onChange).toHaveBeenCalledTimes(2);
-            expect(onChange).toHaveBeenCalledWith(2, 0);
+            expect(onChange).toHaveBeenCalledWith(2, 0, []);
         });
 
         it('calls onChange for every change', () => {
@@ -158,13 +158,13 @@ describe('<ReactSlider>', () => {
             onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
 
             expect(onChange).toHaveBeenCalledTimes(1);
-            expect(onChange).toHaveBeenCalledWith(1, 0);
+            expect(onChange).toHaveBeenCalledWith(1, 0, []);
 
             // simulate keydown
             onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
 
             expect(onChange).toHaveBeenCalledTimes(2);
-            expect(onChange).toHaveBeenCalledWith(0, 0);
+            expect(onChange).toHaveBeenCalledWith(0, 0, []);
         });
 
         it('calls onAfterChange only once after onChange', () => {
@@ -204,14 +204,14 @@ describe('<ReactSlider>', () => {
             onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
 
             expect(onChange).toHaveBeenCalledTimes(1);
-            expect(onChange).toHaveBeenCalledWith(1, 0);
+            expect(onChange).toHaveBeenCalledWith(1, 0, []);
             expect(onAfterChange).not.toHaveBeenCalled();
 
             // simulate keydown
             onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
 
             expect(onChange).toHaveBeenCalledTimes(2);
-            expect(onChange).toHaveBeenCalledWith(2, 0);
+            expect(onChange).toHaveBeenCalledWith(2, 0, []);
             expect(onAfterChange).not.toHaveBeenCalled();
 
             // simulate keyup
@@ -219,7 +219,7 @@ describe('<ReactSlider>', () => {
 
             expect(onChange).toHaveBeenCalledTimes(2);
             expect(onAfterChange).toHaveBeenCalledTimes(1);
-            expect(onAfterChange).toHaveBeenCalledWith(2, 0);
+            expect(onAfterChange).toHaveBeenCalledWith(2, 0, []);
             expect(onAfterChange.mock.invocationCallOrder[0]).toBeGreaterThan(
                 onChange.mock.invocationCallOrder[1]
             );


### PR DESCRIPTION
Fix #229 

I didn't go for the solution of replacing the second argument of the on-change handlers with an array of indices. I thought someone may be interested in differentiating the thumb that the user interacted with directly from the thumbs that moved due to pearling.

So I added a third argument to `onChange` and `onAfterChange`: an array with only the thumbs that were pushed because of pearling. Note that in `onChange`, only the newly pushed thumbs are listed, whereas in `onAfterChange`, it's all the thumbs that were pushed throughout the user's entire interaction with the slider. Of course, since thumbs are pushed after `onBeforeChange` is called, this handler does not receive this third argument.