### PR TITLE
ci: inverted sliders, honor inverted key down handler for horizontal sliders

### DIFF
--- a/src/components/ReactSlider/ReactSlider.jsx
+++ b/src/components/ReactSlider/ReactSlider.jsx
@@ -824,14 +824,28 @@ class ReactSlider extends React.Component {
 
     moveUpByStep(step = this.props.step) {
         const oldValue = this.state.value[this.state.index];
-        const newValue = trimAlignValue(oldValue + step, this.props);
-        this.move(Math.min(newValue, this.props.max));
+
+        // if the slider is inverted and horizontal we want to honor the inverted value
+        const newValue =
+            this.props.invert && this.props.orientation === 'horizontal'
+                ? oldValue - step
+                : oldValue + step;
+
+        const trimAlign = trimAlignValue(newValue, this.props);
+        this.move(Math.min(trimAlign, this.props.max));
     }
 
     moveDownByStep(step = this.props.step) {
         const oldValue = this.state.value[this.state.index];
-        const newValue = trimAlignValue(oldValue - step, this.props);
-        this.move(Math.max(newValue, this.props.min));
+
+        // if the slider is inverted and horizontal we want to honor the inverted value
+        const newValue =
+            this.props.invert && this.props.orientation === 'horizontal'
+                ? oldValue + step
+                : oldValue - step;
+
+        const trimAlign = trimAlignValue(newValue, this.props);
+        this.move(Math.max(trimAlign, this.props.min));
     }
 
     move(newValue) {

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -2,6 +2,11 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import ReactSlider from '../ReactSlider';
 
+jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useState: jest.fn(),
+}));
+
 window.ResizeObserver =
     window.ResizeObserver ||
     jest.fn().mockImplementation(() => ({
@@ -231,6 +236,61 @@ describe('<ReactSlider>', () => {
             expect(onAfterChange.mock.invocationCallOrder[0]).toBeGreaterThan(
                 onChange.mock.invocationCallOrder[1]
             );
+        });
+
+        it('should handle left and right arrow keydown events when the slider is horizontal', async () => {
+            const testRenderer = renderer.create(
+                <ReactSlider min={0} max={10} step={1} thumbClassName="test-thumb" />
+            );
+            const testInstance = testRenderer.root;
+            const thumb = testInstance.findByProps({ className: 'test-thumb test-thumb-0 ' });
+            const { addEventListener } = document;
+
+            // simulate focus on thumb
+            thumb.props.onFocus();
+            expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+            const onKeyDown = addEventListener.mock.calls[0][1];
+
+            onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
+            const valueTestOne = testRenderer.toJSON().children[2].props['aria-valuenow'];
+            expect(valueTestOne).toBe(0);
+
+            thumb.props.onFocus();
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            const valueTestTwo = testRenderer.toJSON().children[2].props['aria-valuenow'];
+            expect(valueTestTwo).toBe(2);
+        });
+
+        it('should handle left and right arrow keydown events when the slider is horizontal and inverted', async () => {
+            const testRenderer = renderer.create(
+                <ReactSlider invert min={0} max={10} step={1} thumbClassName="test-thumb" />
+            );
+
+            const testInstance = testRenderer.root;
+            const thumb = testInstance.findByProps({ className: 'test-thumb test-thumb-0 ' });
+            const { addEventListener } = document;
+
+            // simulate focus on thumb
+            thumb.props.onFocus();
+
+            expect(addEventListener.mock.calls[0][0]).toBe('keydown');
+
+            const onKeyDown = addEventListener.mock.calls[0][1];
+
+            onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
+            onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
+            onKeyDown({ key: 'ArrowLeft', preventDefault: () => {} });
+
+            const valueTestOne = testRenderer.toJSON().children[2].props['aria-valuenow'];
+            expect(valueTestOne).toBe(3);
+
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+            onKeyDown({ key: 'ArrowRight', preventDefault: () => {} });
+
+            const valueTestTwo = testRenderer.toJSON().children[2].props['aria-valuenow'];
+            expect(valueTestTwo).toBe(1);
         });
     });
 

--- a/src/components/ReactSlider/__tests__/ReactSlider.test.js
+++ b/src/components/ReactSlider/__tests__/ReactSlider.test.js
@@ -2,11 +2,6 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import ReactSlider from '../ReactSlider';
 
-jest.mock('react', () => ({
-    ...jest.requireActual('react'),
-    useState: jest.fn(),
-}));
-
 window.ResizeObserver =
     window.ResizeObserver ||
     jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
Fix for the issue: https://github.com/zillow/react-slider/issues/286

Tested on localhost:6060 and all sliders still work as expected

https://zillow.github.io/react-slider/
See the slider "An inverted slider with custom marks" and attempt to press the left and right arrow keys, that behavior will now be inverted with this change